### PR TITLE
Use `first` instead of `filter` when getting the transformer

### DIFF
--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -108,16 +108,13 @@ class Renderer
      */
     protected function optimizeValueForJavaScript($value): string
     {
-        $transformers = $this->getAllTransformers()
-            ->filter(function (Transformer $transformer) use ($value) {
+        return $this->getAllTransformers()
+            ->first(function ($i, Transformer $transformer) use ($value) {
                 return $transformer->canTransform($value);
-            });
-
-        if ($transformers->isEmpty()) {
-            throw Untransformable::noTransformerFound($value);
-        }
-
-        return $transformers->first()->transform($value);
+            }, function () use ($value) {
+                throw Untransformable::noTransformerFound($value);
+            })
+            ->transform($value);
     }
 
     public function getAllTransformers(): Collection


### PR DESCRIPTION
Using `first` allows the `Untransformable` exception to be thrown by default when no compatible transformer is found.

This coincidentally permits the removal of the `$transformers` variable in favor of an inline return statement and `transform` call.