### PR TITLE
Removed type attr on <script> + code style fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Here's an example of how it can be used:
 
 The rendered view will output:
 ```html
-<script type="text/javascript">window['key'] = 'value';</script>
+<script>window['key'] = 'value';</script>
 ```
 
 So in your browser you now have access to a key variable:
@@ -83,7 +83,7 @@ With the package installed you can make use of a `@javascript` Blade directive.
 
 The rendered view will output:
 ```html
-<script type="text/javascript">key = 'value';</script>
+<script>key = 'value';</script>
 ```
 
 You can also use a single argument:
@@ -93,13 +93,13 @@ You can also use a single argument:
 
 This will also output:
 ```html
-<script type="text/javascript">key = 'value';</script>
+<script>key = 'value';</script>
 ```
 
 When setting the namespace to eg `js` in the config file this will be the output:
 
 ```html
-<script type="text/javascript">window['js'] = window['js'] || {};js['key'] = 'value';</script>
+<script>window['js'] = window['js'] || {};js['key'] = 'value';</script>
 ```
 
 ## Changelog

--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -41,7 +41,7 @@ class Renderer
     {
         $variables = $this->normalizeArguments($arguments);
 
-        return '<script type="text/javascript">'.$this->buildJavaScriptSyntax($variables).'</script>';
+        return '<script>'.$this->buildJavaScriptSyntax($variables).'</script>';
     }
 
     /**

--- a/tests/BladeTest.php
+++ b/tests/BladeTest.php
@@ -13,7 +13,7 @@ class BladeTest extends TestCase
     public function it_can_render_a_key_value_pair()
     {
         $this->assertEquals(
-            '<script type="text/javascript">window[\'js\'] = window[\'js\'] || {};window[\'js\'][\'key\'] = \'value\';</script>',
+            '<script>window[\'js\'] = window[\'js\'] || {};window[\'js\'][\'key\'] = \'value\';</script>',
             $this->renderView('keyValue')
         );
     }
@@ -24,7 +24,7 @@ class BladeTest extends TestCase
         $parameter = ['key' => 'value'];
 
         $this->assertEquals(
-            '<script type="text/javascript">window[\'js\'] = window[\'js\'] || {};window[\'js\'][\'key\'] = \'value\';</script>',
+            '<script>window[\'js\'] = window[\'js\'] || {};window[\'js\'][\'key\'] = \'value\';</script>',
             $this->renderView('variable', compact('parameter'))
         );
     }
@@ -35,7 +35,7 @@ class BladeTest extends TestCase
         $parameter = ['number' => 1];
 
         $this->assertEquals(
-            '<script type="text/javascript">window[\'js\'] = window[\'js\'] || {};window[\'js\'][\'number\'] = 1;</script>',
+            '<script>window[\'js\'] = window[\'js\'] || {};window[\'js\'][\'number\'] = 1;</script>',
             $this->renderView('variable', compact('parameter'))
         );
     }
@@ -46,14 +46,14 @@ class BladeTest extends TestCase
         $parameter = ['boolean' => true];
 
         $this->assertEquals(
-            '<script type="text/javascript">window[\'js\'] = window[\'js\'] || {};window[\'js\'][\'boolean\'] = true;</script>',
+            '<script>window[\'js\'] = window[\'js\'] || {};window[\'js\'][\'boolean\'] = true;</script>',
             $this->renderView('variable', compact('parameter'))
         );
 
         $parameter = ['boolean' => false];
 
         $this->assertEquals(
-            '<script type="text/javascript">window[\'js\'] = window[\'js\'] || {};window[\'js\'][\'boolean\'] = false;</script>',
+            '<script>window[\'js\'] = window[\'js\'] || {};window[\'js\'][\'boolean\'] = false;</script>',
             $this->renderView('variable', compact('parameter'))
         );
     }
@@ -64,7 +64,7 @@ class BladeTest extends TestCase
         $parameter = ['nothing' => null];
 
         $this->assertEquals(
-            '<script type="text/javascript">window[\'js\'] = window[\'js\'] || {};window[\'js\'][\'nothing\'] = null;</script>',
+            '<script>window[\'js\'] = window[\'js\'] || {};window[\'js\'][\'nothing\'] = null;</script>',
             $this->renderView('variable', compact('parameter'))
         );
     }
@@ -72,16 +72,15 @@ class BladeTest extends TestCase
     /** @test */
     public function it_can_render_arrayable_objects()
     {
-        $parameter = new class implements Arrayable
- {
-     public function toArray()
-     {
-         return ['arrayableKey' => 'arrayableValue'];
-     }
- };
+        $parameter = new class implements Arrayable {
+            public function toArray()
+            {
+                return ['arrayableKey' => 'arrayableValue'];
+            }
+        };
 
         $this->assertEquals(
-            '<script type="text/javascript">window[\'js\'] = window[\'js\'] || {};window[\'js\'][\'arrayableKey\'] = \'arrayableValue\';</script>',
+            '<script>window[\'js\'] = window[\'js\'] || {};window[\'js\'][\'arrayableKey\'] = \'arrayableValue\';</script>',
             $this->renderView('variable', compact('parameter'))
         );
     }
@@ -89,16 +88,15 @@ class BladeTest extends TestCase
     /** @test */
     public function it_can_render_json_serializable_objects()
     {
-        $parameter = new class implements JsonSerializable
- {
-     public function jsonSerialize()
-     {
-         return ['jsonKey' => 'jsonValue'];
-     }
- };
+        $parameter = new class implements JsonSerializable {
+            public function jsonSerialize()
+            {
+                return ['jsonKey' => 'jsonValue'];
+            }
+        };
 
         $this->assertEquals(
-            '<script type="text/javascript">window[\'js\'] = window[\'js\'] || {};window[\'js\'][\'0\'] = {"jsonKey":"jsonValue"};</script>',
+            '<script>window[\'js\'] = window[\'js\'] || {};window[\'js\'][\'0\'] = {"jsonKey":"jsonValue"};</script>',
             $this->renderView('variable', compact('parameter'))
         );
     }
@@ -106,16 +104,15 @@ class BladeTest extends TestCase
     /** @test */
     public function it_can_render_an_object_that_implements_toJson()
     {
-        $parameter = new class
- {
-     public function toJson()
-     {
-         return json_encode(['jsonKey' => 'jsonValue']);
-     }
- };
+        $parameter = new class {
+            public function toJson()
+            {
+                return json_encode(['jsonKey' => 'jsonValue']);
+            }
+        };
 
         $this->assertEquals(
-            '<script type="text/javascript">window[\'js\'] = window[\'js\'] || {};window[\'js\'][\'0\'] = {"jsonKey":"jsonValue"};</script>',
+            '<script>window[\'js\'] = window[\'js\'] || {};window[\'js\'][\'0\'] = {"jsonKey":"jsonValue"};</script>',
             $this->renderView('variable', compact('parameter'))
         );
     }
@@ -123,16 +120,15 @@ class BladeTest extends TestCase
     /** @test */
     public function it_can_render_an_object_that_implements_to_string()
     {
-        $parameter = new class
- {
-     public function __toString()
-     {
-         return 'string';
-     }
- };
+        $parameter = new class {
+            public function __toString()
+            {
+                return 'string';
+            }
+        };
 
         $this->assertEquals(
-            '<script type="text/javascript">window[\'js\'] = window[\'js\'] || {};window[\'js\'][\'0\'] = \'string\';</script>',
+            '<script>window[\'js\'] = window[\'js\'] || {};window[\'js\'][\'0\'] = \'string\';</script>',
             $this->renderView('variable', compact('parameter'))
         );
     }
@@ -143,7 +139,7 @@ class BladeTest extends TestCase
         $this->app['config']->set('laravel-blade-javascript.namespace', '');
 
         $this->assertEquals(
-            '<script type="text/javascript">window[\'key\'] = \'value\';</script>',
+            '<script>window[\'key\'] = \'value\';</script>',
             $this->renderView('keyValue')
         );
     }


### PR DESCRIPTION
Since HTML5, the ```type``` attribute with ```text/javascript``` [is not necessary](https://developer.mozilla.org/fr/docs/Web/HTML/Element/script#Exemples) on the ```<script>``` tag. So I removed it from various files, changed tests (they still pass of course) and README.md.
I also fixed bad indentation and [incorrect style on anonymous classes](https://github.com/KorvinSzanto/fig-standards/blob/12b82f914ce58664e702a7e8770ecfc99af8d12e/proposed/extended-coding-style-guide.md).