### PR TITLE
Fix missing single quote in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The rendered view will output:
 
 You can also use a single argument:
 ```php
-@javascript(['key' => 'value])
+@javascript(['key' => 'value'])
 ```
 
 This will also output:


### PR DESCRIPTION
Oops, just a missing single quote in the readme example