### PR TITLE
Refactor the way the directive is registered

### DIFF
--- a/src/BladeJavaScriptServiceProvider.php
+++ b/src/BladeJavaScriptServiceProvider.php
@@ -13,12 +13,10 @@ class BladeJavaScriptServiceProvider extends ServiceProvider
             __DIR__.'/../config/blade-javascript.php' => config_path('blade-javascript.php'),
         ], 'config');
 
-        $this->app->afterResolving('blade.compiler', function (BladeCompiler $bladeCompiler) {
-            $bladeCompiler->directive('javascript', function ($expression) {
-                $expression = $this->makeBackwardsCompatible($expression);
+        $this->app['blade.compiler']->directive('javascript', function ($expression) {
+            $expression = $this->makeBackwardsCompatible($expression);
 
-                return "<?= app('\Spatie\BladeJavaScript\Renderer')->render{$expression}; ?>";
-            });
+            return "<?= app('\Spatie\BladeJavaScript\Renderer')->render{$expression}; ?>";
         });
     }
 

--- a/src/BladeJavaScriptServiceProvider.php
+++ b/src/BladeJavaScriptServiceProvider.php
@@ -3,7 +3,6 @@
 namespace Spatie\BladeJavaScript;
 
 use Illuminate\Support\ServiceProvider;
-use Illuminate\View\Compilers\BladeCompiler;
 
 class BladeJavaScriptServiceProvider extends ServiceProvider
 {


### PR DESCRIPTION
I am not exactly sure why (package conflict perhaps?), but the blade directive suddenly stopped working for me in an existing project. It would render the `@javascript` as raw html from the blade file.

After a bit of searching around, it seems Ziggy had a similar issue recently https://github.com/tightenco/ziggy/issues/115. The solution I propose below is the same as they just implemented for their package; and it seems to resolve the issue without breaking backwards compatibility

Thoughts? 

