### PR TITLE
Render Strings with line breaks properly

### DIFF
--- a/src/Transformers/StringTransformer.php
+++ b/src/Transformers/StringTransformer.php
@@ -26,6 +26,6 @@ class StringTransformer implements Transformer
 
     protected function escape(string $value): string
     {
-        return str_replace(['\\', "'"], ['\\\\', "\'"], $value);
+        return str_replace(['\\', "'", "\r", "\n"], ['\\\\', "\'", '\\r', '\\n'], $value);
     }
 }

--- a/tests/BladeTest.php
+++ b/tests/BladeTest.php
@@ -83,10 +83,10 @@ class BladeTest extends TestCase
     /** @test */
     public function it_can_render_a_string_with_line_breaks()
     {
-        $parameter = ['string' => "This is\n a test"];
+        $parameter = ['string' => "This is\r\n a test"];
 
         $this->assertEquals(
-            '<script>window[\'js\'] = window[\'js\'] || {};window[\'js\'][\'string\'] = \'This is\\n a test\';</script>',
+            '<script>window[\'js\'] = window[\'js\'] || {};window[\'js\'][\'string\'] = \'This is\\r\\n a test\';</script>',
             $this->renderView('variable', compact('parameter'))
         );
     }

--- a/tests/BladeTest.php
+++ b/tests/BladeTest.php
@@ -81,6 +81,17 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    public function it_can_render_a_string_with_line_breaks()
+    {
+        $parameter = ['string' => "This is\n a test"];
+
+        $this->assertEquals(
+            '<script>window[\'js\'] = window[\'js\'] || {};window[\'js\'][\'string\'] = \'This is\\n a test\';</script>',
+            $this->renderView('variable', compact('parameter'))
+        );
+    }
+
+    /** @test */
     public function it_can_render_arrayable_objects()
     {
         $parameter = new class implements Arrayable {


### PR DESCRIPTION
When the value has line breaks, such as user input from a `textarea`, the directive did not escape the line breaks properly leading to JavaScript errors.