### PR TITLE
render numeric Strings as Strings

### DIFF
--- a/src/Transformers/NumericTransformer.php
+++ b/src/Transformers/NumericTransformer.php
@@ -11,7 +11,7 @@ class NumericTransformer implements Transformer
      */
     public function canTransform($value): bool
     {
-        return is_numeric($value);
+        return is_int($value) || is_float($value);
     }
 
     /**

--- a/tests/BladeTest.php
+++ b/tests/BladeTest.php
@@ -92,6 +92,17 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    public function it_can_render_a_numeric_string_as_a_string()
+    {
+        $parameter = ['socialSecurity' => '123456789'];
+
+        $this->assertEquals(
+            '<script>window[\'js\'] = window[\'js\'] || {};window[\'js\'][\'socialSecurity\'] = \'123456789\';</script>',
+            $this->renderView('variable', compact('parameter'))
+        );
+    }
+
+    /** @test */
     public function it_can_render_arrayable_objects()
     {
         $parameter = new class implements Arrayable {


### PR DESCRIPTION
Some numeric sequences, such as social security numbers, phone numbers with no formatting, postal codes, etc. Should be rendered as strings, so they can keep leading zeroes for example and do not risk overflowing JavaScript `Number.MAX_SAFE_INTEGER` value.