### PR TITLE
 Improve rendering performance when rendering multiple variables 

### DIFF
--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -27,6 +27,11 @@ class Renderer
         StringTransformer::class,
     ];
 
+    /**
+     * @var Collection
+     */
+    protected $cachedTransformers;
+
     public function __construct(Repository $config)
     {
         $this->namespace = $config->get('blade-javascript.namespace', 'window');
@@ -113,9 +118,14 @@ class Renderer
 
     public function getAllTransformers(): Collection
     {
-        return collect($this->transformers)->map(function (string $className): Transformer {
-            return new $className();
-        });
+        if ($this->cachedTransformers) {
+            return $this->cachedTransformers;
+        }
+
+        return $this->cachedTransformers = collect($this->transformers)
+            ->map(function (string $className): Transformer {
+                return new $className();
+            });
     }
 
     /**

--- a/src/Transformers/NumericTransformer.php
+++ b/src/Transformers/NumericTransformer.php
@@ -11,7 +11,7 @@ class NumericTransformer implements Transformer
      */
     public function canTransform($value): bool
     {
-        return is_numeric($value);
+        return is_int($value) || is_float($value);
     }
 
     /**

--- a/tests/BladeTest.php
+++ b/tests/BladeTest.php
@@ -167,6 +167,17 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    public function it_can_render_multiple_variables()
+    {
+        $parameter = [ 'first' => 1, 'second' => true ];
+
+        $this->assertEquals(
+            '<script>window[\'js\'] = window[\'js\'] || {};window[\'js\'][\'first\'] = 1;window[\'js\'][\'second\'] = true;</script>',
+            $this->renderView('variable', compact('parameter'))
+        );
+    }
+
+    /** @test */
     public function it_can_render_data_without_a_namespace()
     {
         $this->app['config']->set('blade-javascript.namespace', '');

--- a/tests/BladeTest.php
+++ b/tests/BladeTest.php
@@ -169,7 +169,7 @@ class BladeTest extends TestCase
     /** @test */
     public function it_can_render_multiple_variables()
     {
-        $parameter = [ 'first' => 1, 'second' => true ];
+        $parameter = ['first' => 1, 'second' => true];
 
         $this->assertEquals(
             '<script>window[\'js\'] = window[\'js\'] || {};window[\'js\'][\'first\'] = 1;window[\'js\'][\'second\'] = true;</script>',

--- a/tests/BladeTest.php
+++ b/tests/BladeTest.php
@@ -92,6 +92,17 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    public function it_can_render_a_numeric_string_as_a_string()
+    {
+        $parameter = ['socialSecurity' => '123456789'];
+
+        $this->assertEquals(
+            '<script>window[\'js\'] = window[\'js\'] || {};window[\'js\'][\'socialSecurity\'] = \'123456789\';</script>',
+            $this->renderView('variable', compact('parameter'))
+        );
+    }
+
+    /** @test */
     public function it_can_render_arrayable_objects()
     {
         $parameter = new class implements Arrayable {


### PR DESCRIPTION
When passing an array of variables to the rendering the method `getAllTransformers` instantiates the transformers for each variable.

This commit adds a `$cachedTransformers` to the `Renderer` so it instantiates the underlying transformers just once.