### PR TITLE
Escape tags in strings

### DIFF
--- a/src/Transformers/StringTransformer.php
+++ b/src/Transformers/StringTransformer.php
@@ -26,6 +26,6 @@ class StringTransformer implements Transformer
 
     protected function escape(string $value): string
     {
-        return str_replace(['\\', "'", "\r", "\n"], ['\\\\', "\'", '\\r', '\\n'], $value);
+        return str_replace(['\\', "'", "\r", "\n", '<', '>'], ['\\\\', "\'", '\\r', '\\n', '\<', '\>'], $value);
     }
 }

--- a/tests/BladeTest.php
+++ b/tests/BladeTest.php
@@ -103,6 +103,17 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    public function it_escapes_tags_in_a_string()
+    {
+        $parameter = ['string' => "This is a <tag>"];
+
+        $this->assertEquals(
+            '<script>window[\'js\'] = window[\'js\'] || {};window[\'js\'][\'string\'] = \'This is a \<tag\>\';</script>',
+            $this->renderView('variable', compact('parameter'))
+        );
+    }
+
+    /** @test */
     public function it_can_render_arrayable_objects()
     {
         $parameter = new class implements Arrayable {


### PR DESCRIPTION
Escape the `<` and `>` chars to prevent possible JS execution when user input is parsed.